### PR TITLE
Add test for URL source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip
+    - name: Run tests
+      run: pip install pytest && pytest
+    - name: Run type checks
+      run: pip install mypy && mypy .

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1645,3 +1645,45 @@ def test_file_does_not_exist():
 
     with pytest.raises(IOError, match='Failed to read file'):
         parse_html(file_path)
+
+
+#########################################################
+# test url input
+#########################################################
+
+
+def test_url_input():
+    url = 'https://raw.githubusercontent.com/lawcal/html-table-takeout/6ed8fde22d734ea0950cd155a218fb4582d1ad19/tests/test_file_input.html' # pylint: disable=line-too-long
+    expected = [
+        Table(id=0, rows=[
+            TRow(group='tbody', cells=[
+                TCell(header=False, elements=[
+                    TText(text='1'),
+                ]),
+                TCell(header=False, elements=[
+                    TText(text='2'),
+                ]),
+            ]),
+            TRow(group='tbody', cells=[
+                TCell(header=False, elements=[
+                    TText(text='3'),
+                ]),
+                TCell(header=False, elements=[
+                    TText(text='4'),
+                ]),
+            ]),
+        ]),
+    ]
+
+    actual = parse_html(url)
+    assert len(actual) == len(expected)
+    for idx, table in enumerate(actual):
+        assert table == expected[idx]
+
+
+def test_url_resource_does_not_exist():
+
+    url = 'https://raw.githubusercontent.com/lawcal/html-table-takeout/6ed8fde22d734ea0950cd155a218fb4582d1ad19/tests/test_file_input_does_not_exist.html' # pylint: disable=line-too-long
+
+    with pytest.raises(IOError, match='Failed to make HTTP request'):
+        parse_html(url)


### PR DESCRIPTION
## Why
Now that we have uploaded the test HTML file, we can add tests for URL source as input.

We also want to create a GitHub action that automatically runs tests for several Python versions.

## What
- Add tests for URL source
- Add GitHub Actions for automated testing
