### PR TITLE
Append instead of set text when parsing inside link

### DIFF
--- a/html_table_takeout/parser.py
+++ b/html_table_takeout/parser.py
@@ -255,7 +255,7 @@ class _HtmlTableParser(HTMLParser):
         if ctx.in_a: # most specific condition so must be checked first
             cell = ctx.table.rows[-1].cells[-1]
             element = cell.elements[-1]
-            element.text = data
+            element.text += data
 
         elif ctx.in_td:
             cell = ctx.table.rows[-1].cells[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "html-table-takeout"
-version = "1.0.1"
+version = "1.0.2"
 description = "HTML table parser that supports rowspan, colspan, links and nested tables. Fast, lightweight with no external dependencies."
 authors = [
     {name = "Calvin Law"}

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1473,14 +1473,14 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
                 ]),
             ]),
         ]),
-        ('it returns all text within link tags even when there are other elements',"""
+        ('it returns all text within link tags when other elements inside link',"""
 <table>
 <thead>
-    <tr><td>Link in <a href='#1'><span>header</span></a></td></tr>
+    <tr><td>Some <span>header</span> text</td></tr>
 </thead>
-    <tr><td>Link in <a href='#2'>bo<span>dy</span></a></td></tr>
+    <tr><td>Link in <a href='#2'>the <span>[</span>body<span>]</span>!</a></tr>
 <tfoot>
-    <tr><td>Link in <a href='#3'><span>foo</span>ter</a></td></tr>
+    <tr><td><span>Link</span> in <a href='#3'><span>footer</span></a>!</td></tr>
 </tfoot>
 </table>
         """,
@@ -1489,20 +1489,23 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
             Table(id=0, rows=[
                 TRow(group='thead', cells=[
                     TCell(header=False, elements=[
-                        TText(text='Link in '),
-                        TLink(href='#1', text='header'),
+                        TText(text='Some '),
+                        TText(text='header'),
+                        TText(text=' text'),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
                         TText(text='Link in '),
-                        TLink(href='#2', text='body'),
+                        TLink(href='#2', text='the [body]!'),
                     ]),
                 ]),
                 TRow(group='tfoot', cells=[
                     TCell(header=False, elements=[
-                        TText(text='Link in '),
+                        TText(text='Link'),
+                        TText(text=' in '),
                         TLink(href='#3', text='footer'),
+                        TText(text='!'),
                     ]),
                 ]),
             ]),

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1473,6 +1473,40 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
                 ]),
             ]),
         ]),
+        ('it returns all text within link tags even when there are other elements',"""
+<table>
+<thead>
+    <tr><td>Link in <a href='#1'><span>header</span></a></td></tr>
+</thead>
+    <tr><td>Link in <a href='#2'>bo<span>dy</span></a></td></tr>
+<tfoot>
+    <tr><td>Link in <a href='#3'><span>foo</span>ter</a></td></tr>
+</tfoot>
+</table>
+        """,
+        'all',
+        [
+            Table(id=0, rows=[
+                TRow(group='thead', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='Link in '),
+                        TLink(href='#1', text='header'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='Link in '),
+                        TLink(href='#2', text='body'),
+                    ]),
+                ]),
+                TRow(group='tfoot', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='Link in '),
+                        TLink(href='#3', text='footer'),
+                    ]),
+                ]),
+            ]),
+        ]),
     ]
 )
 def test_extract_links(_desc, html_text, extract_links, expected):


### PR DESCRIPTION
## Why
When there are elements inside links like `<a><span>[</span>1<span>]</span></a>`, only the last text node `]` is saved inside the `TLink`. This is because we are assigning the text while parsing within the link tag instead of appending to it.

## What
- Append text while parsing within a link element
- Bumps package version to v1.0.2