### PR TITLE
Logo href in README from relative to absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test](https://github.com/lawcal/html-table-takeout/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/lawcal/html-table-takeout/actions/workflows/test.yml)
 
-<img src="images/html_table_takeout_logo.png" alt="HTML Table Takeout project logo" width="300">
+<img src="https://github.com/lawcal/html-table-takeout/raw/main/images/html_table_takeout_logo.png" alt="HTML Table Takeout project logo" width="300">
 
 A fast, lightweight HTML table parser that supports rowspan, colspan, links and nested tables. No external dependencies are needed.
 


### PR DESCRIPTION
## Why
Currently the logo href is a relative path. This works when viewed on GitHub but the link breaks on PyPI.

## What
- Change logo href to absolute path to the raw image