### PR TITLE
Improve line break handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ print(tables[0].to_html(indent=4))
 The core `parse_html()` function returns a list of zero or more top-level `Table`. A `Table` is guaranteed to have this structure:
 - **rows**: List of one or more `TRow`
   - **cells**: List of zero or more `TCell` resulting from rowspan and colspan expansion
-    - **elements**: List of zero or more `TText`, `TLink`, `TBreak`, `TRef`
+    - **elements**: List of zero or more `TText`, `TLink`, `TRef`
 
 | Type     | Description                                      |
 | -------- | ------------------------------------------------ |
@@ -78,7 +78,6 @@ The core `parse_html()` function returns a list of zero or more top-level `Table
 | `TCell`  | Expanded `<td>` or `<th>` cells from row/colspan |
 | `TText`  | HTML-decoded text inside `<td>` or `<th>`        |
 | `TLink`  | Equal to each `<a>` inside `<td>` or `<th>`      |
-| `TBreak` | Equal to `<br/>`                                 |
 | `TRef`   | Reference to the child `Table`                   |
 
 All tables are guaranteed to have at least one `TRow` containing one `TCell`.

--- a/html_table_takeout/__init__.py
+++ b/html_table_takeout/__init__.py
@@ -1,2 +1,2 @@
 from .parser import parse_html
-from .types import Table, TRow, TCell, TLink, TRef, TBreak, TText
+from .types import Table, TRow, TCell, TLink, TRef, TText

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "html-table-takeout"
-version = "1.0.2"
+version = "1.1.0"
 description = "HTML table parser that supports rowspan, colspan, links and nested tables. Fast, lightweight with no external dependencies."
 authors = [
     {name = "Calvin Law"}

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import re
 import pytest
 
-from html_table_takeout import Table, TRow, TCell, TLink, TRef, TBreak, TText, parse_html
+from html_table_takeout import Table, TRow, TCell, TLink, TRef, TText, parse_html
 
 
 #########################################################
@@ -82,12 +82,12 @@ def append_blank_rows(table: Table, num_rows: int) -> Table:
         ('it parses line breaks', """
 <table>
     <tr>
-        <td>1<br/></td>
-        <td>2</td>
+        <td>1<br/><br/></td>
+        <td>2<br/>3<br/>4</td>
     </tr>
     <tr>
-        <td><br>3</td>
-        <td>4</td>
+        <td><br/>5<br/>6<br/></td>
+        <td><br><br>7</td>
     </tr>
 </table>
          """,
@@ -95,20 +95,54 @@ def append_blank_rows(table: Table, num_rows: int) -> Table:
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1'),
-                        TBreak(),
+                        TText(text='1\n\n'),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2'),
+                        TText(text='2\n3\n4'),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TBreak(),
-                        TText(text='3'),
+                        TText(text='\n5\n6\n'),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='4'),
+                        TText(text='\n\n7'),
+                    ]),
+                ]),
+            ]),
+        ]),
+        ('it parses line breaks in links', """
+<table>
+    <tr>
+        <td><a>1<br/><br/></a></td>
+        <td><br/><a>3<br/>4</a><br/></td>
+    </tr>
+    <tr>
+        <td><a><br/>5<br/>6</a><br/></td>
+        <td><br/>7<br/>8<a><br/></a></td>
+    </tr>
+</table>
+         """,
+        [
+            Table(id=0, rows=[
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TLink(text='1\n\n'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='\n'),
+                        TLink(text='3\n4'),
+                        TText(text='\n'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TLink(text='\n5\n6'),
+                        TText(text='\n'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='\n7\n8'),
+                        TLink(text='\n'),
                     ]),
                 ]),
             ]),
@@ -246,18 +280,18 @@ def append_blank_rows(table: Table, num_rows: int) -> Table:
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1\n'),
+                        TText(text='1 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='3\n'),
+                        TText(text='3 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='4\n'),
+                        TText(text='4 '),
                     ]),
                 ]),
             ]),
@@ -283,26 +317,26 @@ def append_blank_rows(table: Table, num_rows: int) -> Table:
             Table(id=0, rows=[
                 TRow(group='thead', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1\n'),
+                        TText(text='1 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='3\n'),
+                        TText(text='3 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='4\n'),
+                        TText(text='4 '),
                     ]),
                 ]),
                 TRow(group='tfoot', cells=[
                     TCell(header=False, elements=[
-                        TText(text='5\n'),
+                        TText(text='5 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='6\n'),
+                        TText(text='6 '),
                     ]),
                 ]),
             ]),
@@ -343,18 +377,10 @@ def test_structure_nested():
     table_one = Table(id=0, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TBreak(),
-                TText(text='3'),
-                TBreak(),
-                TBreak(),
-                TText(text='4'),
+                TText(text='\n3\n\n4'),
             ]),
             TCell(header=False, elements=[
-                TText(text='5'),
-                TBreak(),
-                TBreak(),
-                TText(text='6'),
-                TBreak(),
+                TText(text='5\n\n6\n'),
             ]),
         ]),
         TRow(group='tbody', cells=[
@@ -699,24 +725,24 @@ def test_structure_nested():
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1\n'),
+                        TText(text='1 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1\n'),
+                        TText(text='1 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                     TCell(header=False, elements=[
-                        TText(text='2\n'),
+                        TText(text='2 '),
                     ]),
                 ]),
             ]),
@@ -1476,7 +1502,7 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
         ('it returns all text within link tags when other elements inside link',"""
 <table>
 <thead>
-    <tr><td>Some <span>header</span> text</td></tr>
+    <tr><td><a href='#1'>Some</a> <span>header</span> text</td></tr>
 </thead>
     <tr><td>Link in <a href='#2'>the <span>[</span>body<span>]</span>!</a></tr>
 <tfoot>
@@ -1489,9 +1515,8 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
             Table(id=0, rows=[
                 TRow(group='thead', cells=[
                     TCell(header=False, elements=[
-                        TText(text='Some '),
-                        TText(text='header'),
-                        TText(text=' text'),
+                        TLink(href='#1', text='Some'),
+                        TText(text=' header text'),
                     ]),
                 ]),
                 TRow(group='tbody', cells=[
@@ -1502,8 +1527,7 @@ def test_displayed_only(_desc, html_text, displayed_only, expected):
                 ]),
                 TRow(group='tfoot', cells=[
                     TCell(header=False, elements=[
-                        TText(text='Link'),
-                        TText(text=' in '),
+                        TText(text='Link in '),
                         TLink(href='#3', text='footer'),
                         TText(text='!'),
                     ]),

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -1,7 +1,7 @@
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long,too-many-lines
 import pytest
 
-from html_table_takeout import Table, TRow, TCell, TLink, TRef, TBreak, TText
+from html_table_takeout import Table, TRow, TCell, TLink, TRef, TText
 
 
 #########################################################
@@ -84,8 +84,7 @@ from html_table_takeout import Table, TRow, TCell, TLink, TRef, TBreak, TText
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1'),
-                        TBreak(),
+                        TText(text='1\n'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='2'),
@@ -93,8 +92,7 @@ from html_table_takeout import Table, TRow, TCell, TLink, TRef, TBreak, TText
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TBreak(),
-                        TText(text='3'),
+                        TText(text='\n3'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='4'),
@@ -268,7 +266,7 @@ def test_table_nested_to_html():
     table_one = Table(id=0, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TText(text='3'),
+                TText(text='3\n4\n5'),
             ]),
         ]),
     ])
@@ -292,7 +290,7 @@ def test_table_nested_to_html():
 <table data-table-id='2'>
 <tbody>
     <tr>
-        <td>1<table data-table-id='1'><tbody><tr><td>2<table data-table-id='0'><tbody><tr><td>3</td></tr></tbody></table></td></tr></tbody></table></td>
+        <td>1<table data-table-id='1'><tbody><tr><td>2<table data-table-id='0'><tbody><tr><td>3<br/>4<br/>5</td></tr></tbody></table></td></tr></tbody></table></td>
     </tr>
 </tbody>
 </table>"""
@@ -352,8 +350,7 @@ def test_table_nested_to_html():
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='1'),
-                        TBreak(),
+                        TText(text='1\n'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='2'),
@@ -361,8 +358,7 @@ def test_table_nested_to_html():
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TBreak(),
-                        TText(text='3'),
+                        TText(text='\n3'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='4'),
@@ -459,8 +455,7 @@ def test_table_nested_to_html():
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='"We want...a SHRUBBERY!'),
-                        TBreak(),
+                        TText(text='"We want...a SHRUBBERY!\n'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='One that\'s nice. And not too expensive."'),
@@ -479,18 +474,12 @@ def test_table_nested_to_csv():
     table_one = Table(id=0, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TBreak(),
-                TText(text='3'),
-                TBreak(),
-                TBreak(),
+                TText(text='\n3\n\n'),
                 TText(text='4'),
             ]),
             TCell(header=False, elements=[
-                TText(text='5'),
-                TBreak(),
-                TBreak(),
-                TText(text='6'),
-                TBreak(),
+                TText(text='5\n\n'),
+                TText(text='6\n'),
             ]),
         ]),
         TRow(group='tbody', cells=[
@@ -498,7 +487,7 @@ def test_table_nested_to_csv():
                 TText(text='7'),
             ]),
             TCell(header=False, elements=[
-                TText(text='8'),
+                TText(text='8\n\n'),
             ]),
         ]),
     ])
@@ -513,11 +502,11 @@ def test_table_nested_to_csv():
     table_three = Table(id=2, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TText(text='1'),
+                TText(text='1\n'),
                 TRef(table=table_two),
             ]),
             TCell(header=False, elements=[
-                TText(text='9'),
+                TText(text='9\n'),
             ]),
         ]),
         TRow(group='tbody', cells=[
@@ -526,7 +515,7 @@ def test_table_nested_to_csv():
             ]),
         ]),
     ])
-    expected = '123 4 5 6 7 8,9\n0\n'
+    expected = '"1\n23\n\n4 5\n\n6\n7 8",9\n0\n'
     assert table_three.to_csv() == expected
 
 
@@ -552,8 +541,7 @@ def test_table_nested_to_csv():
             Table(id=0, rows=[
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TText(text='   1   '),
-                        TBreak(),
+                        TText(text='   1   \n'),
                     ]),
                     TCell(header=False, elements=[
                         TText(text='2   '),
@@ -561,10 +549,7 @@ def test_table_nested_to_csv():
                 ]),
                 TRow(group='tbody', cells=[
                     TCell(header=False, elements=[
-                        TBreak(),
-                        TText(text='3'),
-                        TBreak(),
-                        TBreak(),
+                        TText(text='\n3\n\n'),
                         TText(text='4'),
                     ]),
                     TCell(header=False, elements=[
@@ -572,7 +557,7 @@ def test_table_nested_to_csv():
                     ]),
                 ]),
             ]),
-            '1 2\n3 4 5'
+            '1 2\n3\n\n4 5'
         ),
         ('it returns text portion of links',
             Table(id=0, rows=[
@@ -618,18 +603,12 @@ def test_table_nested_inner_text():
     table_one = Table(id=0, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TBreak(),
-                TText(text='3'),
-                TBreak(),
-                TBreak(),
+                TText(text='\n3\n\n'),
                 TText(text='4'),
             ]),
             TCell(header=False, elements=[
-                TText(text='5'),
-                TBreak(),
-                TBreak(),
-                TText(text='6'),
-                TBreak(),
+                TText(text='5\n\n'),
+                TText(text='6\n'),
             ]),
         ]),
         TRow(group='tbody', cells=[
@@ -637,7 +616,7 @@ def test_table_nested_inner_text():
                 TText(text='7'),
             ]),
             TCell(header=False, elements=[
-                TText(text='8'),
+                TText(text='8\n\n'),
             ]),
         ]),
     ])
@@ -652,11 +631,11 @@ def test_table_nested_inner_text():
     table_three = Table(id=2, rows=[
         TRow(group='tbody', cells=[
             TCell(header=False, elements=[
-                TText(text='1'),
+                TText(text='1\n'),
                 TRef(table=table_two),
             ]),
             TCell(header=False, elements=[
-                TText(text='9'),
+                TText(text='9\n'),
             ]),
         ]),
         TRow(group='tbody', cells=[
@@ -665,7 +644,7 @@ def test_table_nested_inner_text():
             ]),
         ]),
     ])
-    expected = '123 4 5 6 7 8 9\n0'
+    expected = '1\n23\n\n4 5\n\n6\n7 8 9\n0'
     assert table_three.inner_text() == expected
 
 


### PR DESCRIPTION
## Why
The current approach of handling line breaks with`TBreak` is not necessary because they can be directly encoded as `\n` in the text.

This is inconvenient for the end-application because the `TBreak` must be processed separately. If instead line breaks are embedded in a `TText` or `TLink` as `text`, the text is continuous and built-in functions like `split()` may be used.

## What

New approach:
- Remove `TBreak` altogether.
- When parsing HTML text nodes, replace newline characters with a space (newlines in HTML source do not actually create visual line breaks).
- When we encounter a `<br>` tag, append the newline as `\n` inside the `TText` or `TLink`.
- When we convert the `Table` to HTML, restore `\n` as `<br>`.
- Any `\n` inside the `text` should be reflected in HTML, CSV and inner text (except when they're extraneous, like at the beginning or end of a cell).

Other tasks:
- Update and create new tests for this newline handling.
- Update docs.
- Bump version.