### PR TITLE
Iterable Table, TRow, TCell and parsing empty row/colspans attributes

### DIFF
--- a/html_table_takeout/parser.py
+++ b/html_table_takeout/parser.py
@@ -157,8 +157,8 @@ class _HtmlTableParser(HTMLParser):
             cell = TCell(header=tag == 'th')
             # According to spec, rowspan may be zero meaning the cell spans remaining rows in row group:
             # https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
-            rowspan = min(max(0, int(attrs.get('rowspan', 1))), 65534) or 65534 # limits according to spec
-            colspan = min(max(1, int(attrs.get('colspan', 1))), 1000) # limits according to spec
+            rowspan = min(max(0, int(attrs.get('rowspan', '').strip() or 1)), 65534) or 65534 # limits from spec
+            colspan = min(max(1, int(attrs.get('colspan', '').strip() or 1)), 1000) # limits from spec
 
             for _ in range(colspan):
                 row.cells.append(cell)

--- a/html_table_takeout/types.py
+++ b/html_table_takeout/types.py
@@ -47,6 +47,10 @@ class TCell:
     header: bool = False
     elements: list[TText] = field(default_factory=list)
 
+    def __iter__(self):
+        for element in self.elements:
+            yield element
+
     def to_html(self, indent=0) -> str:
         space, _ = _calc_space_newline(indent)
         tag = 'th' if self.header else 'td'
@@ -61,6 +65,10 @@ class TCell:
 class TRow:
     group: Literal['thead', 'tbody', 'tfoot'] = 'tbody'
     cells: list[TCell] = field(default_factory=list)
+
+    def __iter__(self):
+        for cell in self.cells:
+            yield cell
 
     def to_html(self, indent=0) -> str:
         space, newline = _calc_space_newline(indent)
@@ -99,6 +107,9 @@ class Table:
     id: int = -1
     rows: list[TRow] = field(default_factory=list)
 
+    def __iter__(self):
+        for row in self.rows:
+            yield row
 
     def to_html(self, indent=2) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "html-table-takeout"
-version = "1.1.0"
+version = "1.1.1"
 description = "HTML table parser that supports rowspan, colspan, links and nested tables. Fast, lightweight with no external dependencies."
 authors = [
     {name = "Calvin Law"}

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -484,6 +484,58 @@ def test_structure_nested():
                 ]),
             ]),
         ]),
+        ('it handles empty rowspan and colspan attributes as value of one', """
+<<table>
+    <tr>
+         <td rowspan='2' colspan='2'>1</td>
+         <td rowspan=''>2</td>
+    </tr>
+    <tr>
+         <td rowspan='2'>3</td>
+    </tr>
+    <tr>
+         <td rowspan=' 0 '>4</td>
+         <td rowspan='\n0\n'>5</td>
+    </tr>
+</table>
+        """,
+        [
+            Table(id=0, rows=[
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='2'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='3'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='4'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='5'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='3'),
+                    ]),
+                ]),
+            ]),
+        ]),
         ('it handles rowspan and colspan that covers the whole table', """
 <<table>
     <tr>

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -983,6 +983,35 @@ def test_table_nested_rectangify():
 
 
 #########################################################
+# Table __iter__
+#########################################################
+
+
+@pytest.mark.parametrize(
+    '_desc,table,expected',
+    [
+        ('it iterates through table rows',
+            Table(rows=[
+                TRow(cells=[TCell(elements=[TText('a')])]),
+                TRow(cells=[TCell(elements=[TText('b')])]),
+                TRow(cells=[TCell(elements=[TText('c')])]),
+            ]),
+            [
+                TRow(cells=[TCell(elements=[TText('a')])]),
+                TRow(cells=[TCell(elements=[TText('b')])]),
+                TRow(cells=[TCell(elements=[TText('c')])]),
+            ]
+        ),
+    ]
+)
+def test_table_iter(_desc, table: Table, expected):
+    for idx, row in enumerate(table):
+        assert row == expected[idx]
+    for idx, row in enumerate(table.rows):
+        assert row == expected[idx]
+
+
+#########################################################
 # TRow
 #########################################################
 
@@ -1065,3 +1094,61 @@ def test_trow_nested_contains_all_th():
 )
 def test_trow_is_header_like(_desc, row: TRow, expected):
     assert row.is_header_like() == expected
+
+
+#########################################################
+# TRow __iter__
+#########################################################
+
+
+@pytest.mark.parametrize(
+    '_desc,row,expected',
+    [
+        ('it iterates through row cells',
+            TRow(cells=[
+                TCell(elements=[TText('a')]),
+                TCell(elements=[TText('b')]),
+                TCell(elements=[TText('c')]),
+            ]),
+            [
+                TCell(elements=[TText('a')]),
+                TCell(elements=[TText('b')]),
+                TCell(elements=[TText('c')]),
+            ]
+        ),
+    ]
+)
+def test_row_iter(_desc, row: TRow, expected):
+    for idx, cell in enumerate(row):
+        assert cell == expected[idx]
+    for idx, cell in enumerate(row.cells):
+        assert cell == expected[idx]
+
+
+#########################################################
+# TCell __iter__
+#########################################################
+
+
+@pytest.mark.parametrize(
+    '_desc,cell,expected',
+    [
+        ('it iterates through cell elements',
+            TCell(elements=[
+                TText('a'),
+                TText('b'),
+                TText('c'),
+            ]),
+            [
+                TText('a'),
+                TText('b'),
+                TText('c'),
+            ]
+        ),
+    ]
+)
+def test_cell_iter(_desc, cell: TCell, expected):
+    for idx, element in enumerate(cell):
+        assert element == expected[idx]
+    for idx, element in enumerate(cell.elements):
+        assert element == expected[idx]


### PR DESCRIPTION
## Why
Quality of life improvements.

### Improvement 1

When iterating through `Table`, `TRow` or `TCell`.

Instead of:
```
for row in table.rows:
   print(row)
```

We can now also do:
```
for row in table:
   print(row)
```

### Improvement 2

When encountering empty rowspan/colspan attributes, treat it to mean a value of one. Previously, this raised a `ValueError`.

## What

- Implement `__iter__()` for `Table`, `TRow` or `TCell`.
- Treat empty rowspan/colspan attributes as value of one.
- Bump version.