### PR TITLE
Ignore non-digits when parsing row/colspan

### DIFF
--- a/html_table_takeout/parser.py
+++ b/html_table_takeout/parser.py
@@ -22,7 +22,8 @@ def _whitespace_stripped(s: str) -> str:
 
 
 def _parse_span(s: str) -> int:
-    digits = ''.join(c for c in s if c.isdigit())
+    # take integer portion only if decimal
+    digits = ''.join(c for c in s.split('.')[0] if c.isdigit())
     try:
         return int(digits or 1)
     except ValueError:

--- a/html_table_takeout/parser.py
+++ b/html_table_takeout/parser.py
@@ -21,6 +21,15 @@ def _whitespace_stripped(s: str) -> str:
     return ''.join(s.split())
 
 
+def _parse_span(s: str) -> int:
+    digits = ''.join(c for c in s if c.isdigit())
+    try:
+        return int(digits or 1)
+    except ValueError:
+        pass
+    return 1
+
+
 def _has_style_display_none(attrs: dict[str, str | None]) -> bool:
     styles = attrs.get('style') or ''
     return 'display:none' in _whitespace_stripped(styles)
@@ -155,10 +164,11 @@ class _HtmlTableParser(HTMLParser):
 
             # Append the cell from this <td>, colspan times
             cell = TCell(header=tag == 'th')
+            # Limits for rowspan and colspan are from spec.
             # According to spec, rowspan may be zero meaning the cell spans remaining rows in row group:
             # https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
-            rowspan = min(max(0, int(attrs.get('rowspan', '').strip() or 1)), 65534) or 65534 # limits from spec
-            colspan = min(max(1, int(attrs.get('colspan', '').strip() or 1)), 1000) # limits from spec
+            rowspan = min(max(0, _parse_span(attrs.get('rowspan', ''))), 65534) or 65534
+            colspan = min(max(1, _parse_span(attrs.get('colspan', ''))), 1000)
 
             for _ in range(colspan):
                 row.cells.append(cell)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "html-table-takeout"
-version = "1.1.1"
+version = "1.1.2"
 description = "HTML table parser that supports rowspan, colspan, links and nested tables. Fast, lightweight with no external dependencies."
 authors = [
     {name = "Calvin Law"}

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -536,6 +536,58 @@ def test_structure_nested():
                 ]),
             ]),
         ]),
+        ('it handles rowspan and colspan attributes with non-digits', """
+<<table>
+    <tr>
+         <td rowspan='2;' colspan=';2'>1</td>
+         <td rowspan='value of one'>2</td>
+    </tr>
+    <tr>
+         <td rowspan=';;2.9;;'>3</td>
+    </tr>
+    <tr>
+         <td rowspan=' ;; 0 ;; '>4</td>
+         <td rowspan='\n0\n'>5</td>
+    </tr>
+</table>
+        """,
+        [
+            Table(id=0, rows=[
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='2'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='1'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='3'),
+                    ]),
+                ]),
+                TRow(group='tbody', cells=[
+                    TCell(header=False, elements=[
+                        TText(text='4'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='5'),
+                    ]),
+                    TCell(header=False, elements=[
+                        TText(text='3'),
+                    ]),
+                ]),
+            ]),
+        ]),
         ('it handles rowspan and colspan that covers the whole table', """
 <<table>
     <tr>

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -539,7 +539,7 @@ def test_structure_nested():
         ('it handles rowspan and colspan attributes with non-digits', """
 <<table>
     <tr>
-         <td rowspan='2;' colspan=';2'>1</td>
+         <td rowspan='2.0;' colspan=';2'>1</td>
          <td rowspan='value of one'>2</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Why
As reported in https://github.com/lawcal/html-table-takeout/issues/10, some wiki articles may contain trailing semicolons in row/colspan attributes.

Although the [HTML table spec](https://html.spec.whatwg.org/multipage/tables.html) says they must be non-negative integers, our parser can be made more lenient by ignoring non-digits to support more tables in the wild.

## What
- Parse row/colspan more leniently by ignoring non-digits.
- Add tests for various non-digit characters in row/colspan.
- Bump version.

## Testing

We should be able to parse this table from the wiki now:
```python
from html_table_takeout import parse_html

url = 'https://en.wikipedia.org/wiki/2024_United_States_presidential_election_in_Florida'

print(len(parse_html(url)))
# 28
```